### PR TITLE
Fix version file generation for tests

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -7,6 +7,11 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$SCRIPT_DIR"
 export PYTHONPATH="$SCRIPT_DIR/app/Lib:$PYTHONPATH"
 
+# Ensure version file exists for scripts that import it
+if [ ! -f "$SCRIPT_DIR/app/Lib/gftools/_version.py" ]; then
+  echo "version = '0.0.0'" > "$SCRIPT_DIR/app/Lib/gftools/_version.py"
+fi
+
 # --- CONFIGURE THIS SECTION ---
 # Replace this with your command to run all tests
 run_all_tests() {


### PR DESCRIPTION
## Summary
- revert stray _version.py addition
- ensure run.sh writes a minimal version file before running tests

## Testing
- `./run.sh` *(fails: ModuleNotFoundError for optional dependencies)*